### PR TITLE
:sparkles: add extra client for workload clusters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,95 @@
+run:
+  deadline: 5m
+  skip-files: []
+  skip-dirs: []
+
+linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+  gocyclo:
+    min-complexity: 15
+  maligned:
+    suggest-new: true
+  goconst:
+    min-len: 5
+    min-occurrences: 3
+  misspell:
+    locale: US
+  funlen:
+    lines: -1
+    statements: 50
+  godox:
+    keywords:
+      - FIXME
+  gofumpt:
+    extra-rules: true
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    packages:
+      - github.com/pkg/errors
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+    disabled-checks:
+      - sloppyReassign
+      - rangeValCopy
+      - octalLiteral
+      - paramTypeCombine # already handle by gofumpt.extra-rules
+    settings:
+      hugeParam:
+        sizeThreshold: 220 # todo must be improved
+
+linters:
+  enable-all: true
+  disable:
+    - maligned # deprecated
+    - interfacer # deprecated
+    - scopelint # deprecated
+    - golint # deprecated
+    - deadcode # deprecated
+    - nosnakecase # deprecated
+    - structcheck # deprecated
+    - varcheck # deprecated
+    - sqlclosecheck # not relevant (SQL)
+    - rowserrcheck # not relevant (SQL)
+    - cyclop # duplicate of gocyclo
+    - lll
+    - dupl
+    - wsl
+    - nlreturn
+    - gomnd
+    - goerr113
+    - wrapcheck
+    - exhaustive
+    - exhaustivestruct
+    - exhaustruct
+    - testpackage
+    - tparallel
+    - paralleltest
+    - prealloc
+    - ifshort
+    - forcetypeassert
+    - bodyclose # Too many false positives: https://github.com/timakin/bodyclose/issues/30
+    - varnamelen
+    - ireturn
+    - contextcheck
+    - nonamedreturns
+
+issues:
+  exclude-use-default: false
+  max-per-linter: 0
+  max-same-issues: 0
+  exclude:
+    - 'ST1000: at least one file in a package should have a package comment'
+    - 'package-comments: should have a package comment'
+    - 'G204: Subprocess launched with variable'
+    - 'G304: Potential file inclusion via variable'
+  exclude-rules:
+    - path: .main.go
+      linters:
+        - forbidigo

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 rwildcard=$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call rwildcard,$(d)/,$(2)) $(filter $(subst *,%,$(2)),$(d)))
 
-all: test build
+all: lint test build
 
 tidy:
 	go mod tidy -compat=1.19
@@ -22,6 +22,9 @@ fmt:
 
 test:
 	go test -coverprofile coverage.out -v ./...
+
+lint:
+	golangci-lint run
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -36,33 +36,53 @@ gitops-zombies --context staging -l app.kubernetes.io/managed-by!=kops,app.kuber
 
 ## CLI reference
 ```
-Finds all kubernetes resources from all installed apis on a kubernetes cluste and evaluates whether they are managed by a flux kustomization or a helmrelease.
+Finds all kubernetes resources from all installed apis on a kubernetes cluster and evaluates whether they are managed by a flux kustomization or a helmrelease.
 
 Usage:
   gitops-zombies [flags]
 
 Flags:
-      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --as-uid string                  UID to impersonate for the operation.
-      --cache-dir string               Default cache directory (default "/home/raffi/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-  -h, --help                           help for gitops-zombies
-  -a, --include-all                    Includes resources which are considered dynamic resources
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-  -o, --output string                  Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file, custom-columns, custom-columns-file, wide). See custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -l, --selector string                Label selector (Is used for all apis)
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
-  -v, --verbose                        Verbose mode (Logged to stderr)
-      --version                        Print version and exit
+      --cluster-as string                      Username to impersonate for the operation
+      --cluster-as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --cluster-as-uid string                  UID to impersonate for the operation
+      --cluster-certificate-authority string   Path to a cert file for the certificate authority
+      --cluster-client-certificate string      Path to a client certificate file for TLS
+      --cluster-client-key string              Path to a client key file for TLS
+      --cluster-cluster string                 The name of the kubeconfig cluster to use
+      --cluster-context string                 The name of the kubeconfig context to use
+      --cluster-insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  -n, --cluster-namespace string               If present, the namespace scope for this CLI request
+      --cluster-password string                Password for basic authentication to the API server
+      --cluster-proxy-url string               If provided, this URL will be used to connect via proxy
+      --cluster-request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --cluster-server string                  The address and port of the Kubernetes API server
+      --cluster-tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --cluster-token string                   Bearer token for authentication to the API server
+      --cluster-user string                    The name of the kubeconfig user to use
+      --cluster-username string                Username for basic authentication to the API server
+      --gitops-as string                       Username to impersonate for the operation
+      --gitops-as-group stringArray            Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --gitops-as-uid string                   UID to impersonate for the operation
+      --gitops-certificate-authority string    Path to a cert file for the certificate authority
+      --gitops-client-certificate string       Path to a client certificate file for TLS
+      --gitops-client-key string               Path to a client key file for TLS
+      --gitops-cluster string                  The name of the kubeconfig cluster to use
+      --gitops-context string                  The name of the kubeconfig context to use
+      --gitops-insecure-skip-tls-verify        If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --gitops-namespace string                If present, the namespace scope for this CLI request
+      --gitops-password string                 Password for basic authentication to the API server
+      --gitops-proxy-url string                If provided, this URL will be used to connect via proxy
+      --gitops-request-timeout string          The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+      --gitops-server string                   The address and port of the Kubernetes API server
+      --gitops-tls-server-name string          If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
+      --gitops-token string                    Bearer token for authentication to the API server
+      --gitops-user string                     The name of the kubeconfig user to use
+      --gitops-username string                 Username for basic authentication to the API server
+  -h, --help                                   help for gitops-zombies
+  -a, --include-all                            Includes resources which are considered dynamic resources
+      --kubeconfig string                      Path to the kubeconfig file to use for CLI requests. (default "/home/johndoe/.kube/config")
+  -o, --output string                          Output format. One of: (json, yaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file, custom-columns, custom-columns-file, wide). See custom columns [https://kubernetes.io/docs/reference/kubectl/overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].
+  -l, --selector string                        Label selector (is used for all apis)
+  -v, --verbose                                Verbose mode (logged to stderr)
+      --version                                Print version and exit
 ```

--- a/cmd/blacklist.go
+++ b/cmd/blacklist.go
@@ -4,60 +4,62 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// backlist are resources which are ignored from validation
-var blacklist []schema.GroupVersionResource = []schema.GroupVersionResource{
-	{
-		Version:  "v1",
-		Resource: "events",
-	},
-	{
-		Version:  "v1",
-		Resource: "endpoints",
-	},
-	{
-		Version:  "v1",
-		Resource: "componentstatuses",
-	},
-	{
-		Version:  "v1",
-		Resource: "persistentvolumeclaims",
-	},
-	{
-		Version:  "v1",
-		Resource: "persistentvolumes",
-	},
-	{
-		Version:  "v1",
-		Group:    "storage.k8s.io",
-		Resource: "volumeattachments",
-	},
-	{
-		Version:  "v1",
-		Resource: "nodes",
-	},
-	{
-		Version:  "v1beta1",
-		Group:    "events.k8s.io",
-		Resource: "events",
-	},
-	{
-		Version:  "v1",
-		Group:    "events.k8s.io",
-		Resource: "events",
-	},
-	{
-		Version:  "v1beta1",
-		Group:    "metrics.k8s.io",
-		Resource: "pods",
-	},
-	{
-		Version:  "v1beta1",
-		Group:    "metrics.k8s.io",
-		Resource: "nodes",
-	},
-	{
-		Version:  "v1",
-		Group:    "coordination.k8s.io",
-		Resource: "leases",
-	},
+// backlist are resources which are ignored from validation.
+func getBlacklist() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		{
+			Version:  "v1",
+			Resource: "events",
+		},
+		{
+			Version:  "v1",
+			Resource: "endpoints",
+		},
+		{
+			Version:  "v1",
+			Resource: "componentstatuses",
+		},
+		{
+			Version:  "v1",
+			Resource: "persistentvolumeclaims",
+		},
+		{
+			Version:  "v1",
+			Resource: "persistentvolumes",
+		},
+		{
+			Version:  "v1",
+			Group:    "storage.k8s.io",
+			Resource: "volumeattachments",
+		},
+		{
+			Version:  "v1",
+			Resource: "nodes",
+		},
+		{
+			Version:  "v1beta1",
+			Group:    "events.k8s.io",
+			Resource: "events",
+		},
+		{
+			Version:  "v1",
+			Group:    "events.k8s.io",
+			Resource: "events",
+		},
+		{
+			Version:  "v1beta1",
+			Group:    "metrics.k8s.io",
+			Resource: "pods",
+		},
+		{
+			Version:  "v1beta1",
+			Group:    "metrics.k8s.io",
+			Resource: "nodes",
+		},
+		{
+			Version:  "v1",
+			Group:    "coordination.k8s.io",
+			Resource: "leases",
+		},
+	}
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func contextsCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func contextsCompletionFunc(kubeconfigArgs *genericclioptions.ConfigFlags, toComplete string) ([]string, cobra.ShellCompDirective) {
 	rawConfig, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
 		return completionError(err)

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-func contextsCompletionFunc(kubeconfigArgs *genericclioptions.ConfigFlags, toComplete string) ([]string, cobra.ShellCompDirective) {
-	rawConfig, err := kubeconfigArgs.ToRawKubeConfigLoader().RawConfig()
+func contextsCompletionFunc(kubeconfig clientcmd.ClientConfig, toComplete string) ([]string, cobra.ShellCompDirective) {
+	rawConfig, err := kubeconfig.RawConfig()
 	if err != nil {
 		return completionError(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741
 	gotest.tools/v3 v3.0.3
 	k8s.io/apimachinery v0.25.2
-	k8s.io/cli-runtime v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/kubectl v0.25.2
 )
@@ -70,6 +69,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.25.2 // indirect
+	k8s.io/cli-runtime v0.25.2 // indirect
 	k8s.io/component-base v0.25.2 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module gihub.com/raffis/flux-zombies
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.5.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741
 	gotest.tools/v3 v3.0.3
 	k8s.io/apimachinery v0.25.2
@@ -52,6 +53,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect

--- a/pkg/collector/resource.go
+++ b/pkg/collector/resource.go
@@ -7,14 +7,16 @@ import (
 )
 
 const (
-	FLUX_HELM_NAME_LABEL           = "helm.toolkit.fluxcd.io/name"
-	FLUX_HELM_NAMESPACE_LABEL      = "helm.toolkit.fluxcd.io/namespace"
-	FLUX_KUSTOMIZE_NAME_LABEL      = "kustomize.toolkit.fluxcd.io/name"
-	FLUX_KUSTOMIZE_NAMESPACE_LABEL = "kustomize.toolkit.fluxcd.io/namespace"
+	fluxHelmNameLabel           = "helm.toolkit.fluxcd.io/name"
+	fluxHelmNamespaceLabel      = "helm.toolkit.fluxcd.io/namespace"
+	fluxKustomizeNameLabel      = "kustomize.toolkit.fluxcd.io/name"
+	fluxKustomizeNamespaceLabel = "kustomize.toolkit.fluxcd.io/namespace"
 )
 
+// FilterFunc is a function that filters resources.
 type FilterFunc func(res unstructured.Unstructured, logger logger) bool
 
+// Interface represents collector interface.
 type Interface interface {
 	Discover(ctx context.Context, list *unstructured.UnstructuredList, ch chan unstructured.Unstructured) error
 }
@@ -28,6 +30,7 @@ type discovery struct {
 	logger  logger
 }
 
+// NewDiscovery returns a new discovery instance.
 func NewDiscovery(logger logger, filters ...FilterFunc) Interface {
 	return &discovery{
 		logger:  logger,
@@ -35,6 +38,7 @@ func NewDiscovery(logger logger, filters ...FilterFunc) Interface {
 	}
 }
 
+// Discover validates discovered resources against all filters and adds it to consumer channel.
 func (d *discovery) Discover(ctx context.Context, list *unstructured.UnstructuredList, ch chan unstructured.Unstructured) error {
 RESOURCES:
 	for _, res := range list.Items {
@@ -52,6 +56,7 @@ RESOURCES:
 	return nil
 }
 
+// IgnoreOwnedResource returns a FilterFunc which filters resources owner by parents ones.
 func IgnoreOwnedResource() FilterFunc {
 	return func(res unstructured.Unstructured, logger logger) bool {
 		if refs := res.GetOwnerReferences(); len(refs) > 0 {
@@ -63,6 +68,7 @@ func IgnoreOwnedResource() FilterFunc {
 	}
 }
 
+// IgnoreServiceAccountSecret returns a FilterFunc which filters secrets linked to a service account.
 func IgnoreServiceAccountSecret() FilterFunc {
 	return func(res unstructured.Unstructured, logger logger) bool {
 		if res.GetKind() == "Secret" && res.GetAPIVersion() == "v1" {
@@ -75,6 +81,7 @@ func IgnoreServiceAccountSecret() FilterFunc {
 	}
 }
 
+// IgnoreHelmSecret returns a FilterFunc which filters secrets owned by helm.
 func IgnoreHelmSecret() FilterFunc {
 	return func(res unstructured.Unstructured, logger logger) bool {
 		if res.GetKind() == "Secret" && res.GetAPIVersion() == "v1" {
@@ -87,16 +94,16 @@ func IgnoreHelmSecret() FilterFunc {
 	}
 }
 
+// IgnoreIfHelmReleaseFound returns a FilterFunc which filters resources part of an helm release.
 func IgnoreIfHelmReleaseFound(helmReleases []unstructured.Unstructured) FilterFunc {
 	return func(res unstructured.Unstructured, logger logger) bool {
 		labels := res.GetLabels()
-		if helmName, ok := labels[FLUX_HELM_NAME_LABEL]; ok {
-			if helmNamespace, ok := labels[FLUX_HELM_NAMESPACE_LABEL]; ok {
+		if helmName, ok := labels[fluxHelmNameLabel]; ok {
+			if helmNamespace, ok := labels[fluxHelmNamespaceLabel]; ok {
 				if hasResource(helmReleases, helmName, helmNamespace) {
 					return true
-				} else {
-					logger.Debugf("helmrelease [%s.%s] not found from resource  %s %s %s\n", helmName, helmNamespace, res.GetName(), res.GetNamespace(), res.GetAPIVersion())
 				}
+				logger.Debugf("helmrelease [%s.%s] not found from resource  %s %s %s\n", helmName, helmNamespace, res.GetName(), res.GetNamespace(), res.GetAPIVersion())
 			}
 		}
 
@@ -104,16 +111,16 @@ func IgnoreIfHelmReleaseFound(helmReleases []unstructured.Unstructured) FilterFu
 	}
 }
 
+// IgnoreIfKustomizationFound returns a FilterFunc which filters resources part of a flux kustomization.
 func IgnoreIfKustomizationFound(kustomizations []unstructured.Unstructured) FilterFunc {
 	return func(res unstructured.Unstructured, logger logger) bool {
 		labels := res.GetLabels()
-		if ksName, ok := labels[FLUX_KUSTOMIZE_NAME_LABEL]; ok {
-			if ksNamespace, ok := labels[FLUX_KUSTOMIZE_NAMESPACE_LABEL]; ok {
+		if ksName, ok := labels[fluxKustomizeNameLabel]; ok {
+			if ksNamespace, ok := labels[fluxKustomizeNamespaceLabel]; ok {
 				if hasResource(kustomizations, ksName, ksNamespace) {
 					return true
-				} else {
-					logger.Debugf("kustomization [%s.%s] not found from resource  %s %s %s\n", ksName, ksNamespace, res.GetName(), res.GetNamespace(), res.GetAPIVersion())
 				}
+				logger.Debugf("kustomization [%s.%s] not found from resource  %s %s %s\n", ksName, ksNamespace, res.GetName(), res.GetNamespace(), res.GetAPIVersion())
 			}
 		}
 


### PR DESCRIPTION
Hello,

This PR:
- adds golangci-lint to improve code quality checks
- adds a second k8s client to check remote clusters managed by flux

Rémi