### PR TITLE
:tada: add exclusion filters for labels and annotations

### DIFF
--- a/pkg/apis/gitopszombies/v1/types.go
+++ b/pkg/apis/gitopszombies/v1/types.go
@@ -17,8 +17,10 @@ type Config struct {
 
 // ExcludeResources configures filters to exclude resources from zombies list.
 type ExcludeResources struct {
-	Cluster         *string `json:"cluster,omitempty"`
-	Name            *string `json:"name,omitempty"`
-	Namespace       *string `json:"namespace,omitempty"`
+	Cluster         *string           `json:"cluster,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	Name            *string           `json:"name,omitempty"`
+	Namespace       *string           `json:"namespace,omitempty"`
 	metav1.TypeMeta `json:",inline"`
 }

--- a/pkg/apis/gitopszombies/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/gitopszombies/v1/zz_generated.deepcopy.go
@@ -65,6 +65,20 @@ func (in *ExcludeResources) DeepCopyInto(out *ExcludeResources) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)

--- a/pkg/collector/resource.go
+++ b/pkg/collector/resource.go
@@ -166,6 +166,14 @@ func IgnoreRuleExclusions(cluster string, exclusions []v1.ExcludeResources) Filt
 				continue
 			}
 
+			if !resourceMatchesAnnotations(res, exclusion.Annotations) {
+				continue
+			}
+
+			if !resourceMatchesLabels(res, exclusion.Labels) {
+				continue
+			}
+
 			if resourceMatchesName(res, exclusion.Name) {
 				return true
 			}
@@ -209,6 +217,52 @@ func resourceMatchesNamespace(res unstructured.Unstructured, namespace *string) 
 		}
 		if !match {
 			return false
+		}
+	}
+
+	return true
+}
+
+func resourceMatchesAnnotations(res unstructured.Unstructured, annotations map[string]string) bool {
+	if annotations != nil {
+		resAnnotations := res.GetAnnotations()
+
+		for key, val := range annotations {
+			v, ok := resAnnotations[key]
+			if !ok {
+				return false
+			}
+
+			match, err := regexp.MatchString(`^`+val+`$`, v)
+			if err != nil {
+				klog.Error(err)
+			}
+			if !match {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func resourceMatchesLabels(res unstructured.Unstructured, labels map[string]string) bool {
+	if labels != nil {
+		resLabels := res.GetLabels()
+
+		for key, val := range labels {
+			v, ok := resLabels[key]
+			if !ok {
+				return false
+			}
+
+			match, err := regexp.MatchString(`^`+val+`$`, v)
+			if err != nil {
+				klog.Error(err)
+			}
+			if !match {
+				return false
+			}
 		}
 	}
 

--- a/pkg/collector/resource.go
+++ b/pkg/collector/resource.go
@@ -166,11 +166,11 @@ func IgnoreRuleExclusions(cluster string, exclusions []v1.ExcludeResources) Filt
 				continue
 			}
 
-			if !resourceMatchesAnnotations(res, exclusion.Annotations) {
+			if !resourceMatchesMetadata(res.GetAnnotations(), exclusion.Annotations) {
 				continue
 			}
 
-			if !resourceMatchesLabels(res, exclusion.Labels) {
+			if !resourceMatchesMetadata(res.GetLabels(), exclusion.Labels) {
 				continue
 			}
 
@@ -223,46 +223,19 @@ func resourceMatchesNamespace(res unstructured.Unstructured, namespace *string) 
 	return true
 }
 
-func resourceMatchesAnnotations(res unstructured.Unstructured, annotations map[string]string) bool {
-	if annotations != nil {
-		resAnnotations := res.GetAnnotations()
-
-		for key, val := range annotations {
-			v, ok := resAnnotations[key]
-			if !ok {
-				return false
-			}
-
-			match, err := regexp.MatchString(`^`+val+`$`, v)
-			if err != nil {
-				klog.Error(err)
-			}
-			if !match {
-				return false
-			}
+func resourceMatchesMetadata(resMetadata, metadata map[string]string) bool {
+	for key, val := range metadata {
+		v, ok := resMetadata[key]
+		if !ok {
+			return false
 		}
-	}
 
-	return true
-}
-
-func resourceMatchesLabels(res unstructured.Unstructured, labels map[string]string) bool {
-	if labels != nil {
-		resLabels := res.GetLabels()
-
-		for key, val := range labels {
-			v, ok := resLabels[key]
-			if !ok {
-				return false
-			}
-
-			match, err := regexp.MatchString(`^`+val+`$`, v)
-			if err != nil {
-				klog.Error(err)
-			}
-			if !match {
-				return false
-			}
+		match, err := regexp.MatchString(`^`+val+`$`, v)
+		if err != nil {
+			klog.Error(err)
+		}
+		if !match {
+			return false
 		}
 	}
 

--- a/pkg/collector/resource_test.go
+++ b/pkg/collector/resource_test.go
@@ -46,6 +46,7 @@ func getExclusionListResourceSet() *unstructured.UnstructuredList {
 		Version: "v1",
 		Kind:    "Backup",
 	})
+	res1.SetAnnotations(map[string]string{"test-annotation": "velero-capi-backup-1"})
 
 	res2 := unstructured.Unstructured{}
 	res2.SetName("velero-capi-backup-2")
@@ -55,6 +56,7 @@ func getExclusionListResourceSet() *unstructured.UnstructuredList {
 		Version: "v2",
 		Kind:    "Backup",
 	})
+	res2.SetLabels(map[string]string{"test-label": "velero-capi-backup-2"})
 
 	res3 := unstructured.Unstructured{}
 	res3.SetName("velero-capi-backup-3")
@@ -386,6 +388,54 @@ func TestDiscovery(t *testing.T) {
 			},
 			list:         getExclusionListResourceSet,
 			expectedPass: 0,
+		},
+		{
+			name: "Resources excluded from conf: match restricted by annotation",
+			filters: func() []FilterFunc {
+				return []FilterFunc{IgnoreRuleExclusions("test", []gitopszombiesv1.ExcludeResources{
+					{
+						Annotations: map[string]string{"test-annotation": "velero-capi-backup-1"},
+					},
+				})}
+			},
+			list:         getExclusionListResourceSet,
+			expectedPass: 2,
+		},
+		{
+			name: "Resources excluded from conf: match restricted by annotation (regexp)",
+			filters: func() []FilterFunc {
+				return []FilterFunc{IgnoreRuleExclusions("test", []gitopszombiesv1.ExcludeResources{
+					{
+						Annotations: map[string]string{"test-annotation": "v.*"},
+					},
+				})}
+			},
+			list:         getExclusionListResourceSet,
+			expectedPass: 2,
+		},
+		{
+			name: "Resources excluded from conf: match restricted by label",
+			filters: func() []FilterFunc {
+				return []FilterFunc{IgnoreRuleExclusions("test", []gitopszombiesv1.ExcludeResources{
+					{
+						Labels: map[string]string{"test-label": "velero-capi-backup-2"},
+					},
+				})}
+			},
+			list:         getExclusionListResourceSet,
+			expectedPass: 2,
+		},
+		{
+			name: "Resources excluded from conf: match restricted by label (regexp)",
+			filters: func() []FilterFunc {
+				return []FilterFunc{IgnoreRuleExclusions("test", []gitopszombiesv1.ExcludeResources{
+					{
+						Labels: map[string]string{"test-label": "v.*"},
+					},
+				})}
+			},
+			list:         getExclusionListResourceSet,
+			expectedPass: 2,
 		},
 		{
 			name: "Resources excluded from conf: match restricted by name",


### PR DESCRIPTION
This PR adds exclusion filters for labels and annotation. You may now filter resources this way:

 ```yaml
- name: .*-tls
  labels:
    controller.cert-manager.io/fao: "true"
  apiVersion: v1
  kind: Secret
 ```