### PR TITLE
fix: flux v2.8+ compatibility

### DIFF
--- a/pkg/collector/resource.go
+++ b/pkg/collector/resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 
 	helmapi "github.com/fluxcd/helm-controller/api/v2"
-	ksapi "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	ksapi "github.com/fluxcd/kustomize-controller/api/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/object"

--- a/pkg/collector/resource_test.go
+++ b/pkg/collector/resource_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	helmapi "github.com/fluxcd/helm-controller/api/v2"
-	ksapi "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	ksapi "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/detector/clients.go
+++ b/pkg/detector/clients.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ksapi "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	ksapi "github.com/fluxcd/kustomize-controller/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	helmapi "github.com/fluxcd/helm-controller/api/v2"
-	ksapi "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	ksapi "github.com/fluxcd/kustomize-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/detector/gitops_resources.go
+++ b/pkg/detector/gitops_resources.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	helmapi "github.com/fluxcd/helm-controller/api/v2"
-	ksapi "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	ksapi "github.com/fluxcd/kustomize-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
# Motivation

The Flux APIs `v1beta2` and `v2beta2` (deprecated in 2024) have reached end-of-life and have been removed from the CRDs.